### PR TITLE
Upgrade debug6 PR (#29)

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -160,8 +160,6 @@ const string engine_info(bool to_uci) {
 
 const std::string compiler_info() {
 
-  #define stringify2(x) #x
-  #define stringify(x) stringify2(x)
   #define make_version_string(major, minor, patch) stringify(major) "." stringify(minor) "." stringify(patch)
 
 /// Predefined macros hell:

--- a/src/misc.h
+++ b/src/misc.h
@@ -28,7 +28,7 @@
 #include <vector>
 
 #include "types.h"
-
+#include "uci.h" // for testing uci variables.
 const std::string engine_info(bool to_uci = false);
 const std::string compiler_info();
 void prefetch(void* addr);
@@ -111,5 +111,40 @@ public:
 namespace WinProcGroup {
   void bindThisThread(size_t idx);
 }
+
+// get number of arguments with __NARG__
+#define __NARG__(...)  __NARG_I_(__VA_ARGS__,__RSEQ_N())
+#define __NARG_I_(...) __ARG_N(__VA_ARGS__)
+#define __ARG_N( \
+      _1, _2, _3, _4, _5, _6, _7, _8, _9,_10, \
+     _11,_12,_13,_14,_15,_16,_17,_18,_19,_20, \
+     _21,_22,_23,_24,_25,_26,_27,_28,_29,_30, \
+     _31,_32,_33,_34,_35,_36,_37,_38,_39,_40, \
+     _41,_42,_43,_44,_45,_46,_47,_48,_49,_50, \
+     _51,_52,_53,_54,_55,_56,_57,_58,_59,_60, \
+     _61,_62,_63,N,...) N
+#define __RSEQ_N() \
+     63,62,61,60,                   \
+     59,58,57,56,55,54,53,52,51,50, \
+     49,48,47,46,45,44,43,42,41,40, \
+     39,38,37,36,35,34,33,32,31,30, \
+     29,28,27,26,25,24,23,22,21,20, \
+     19,18,17,16,15,14,13,12,11,10, \
+     9,8,7,6,5,4,3,2,1,0
+
+// general definition for any function name
+#define _VFUNC_(name, n) name##n
+#define _VFUNC(name, n) _VFUNC_(name, n)
+#define VFUNC(func, ...) _VFUNC(func, __NARG__(__VA_ARGS__)) (__VA_ARGS__)
+
+
+#define stringify2(x) #x
+#define stringify(x) stringify2(x)
+#define stringifyany1(a) stringify(a)
+#define stringifyany2(a,b) stringify(a) "," stringify(b) 
+#define stringifyany(...) VFUNC(stringifyany,__VA_ARGS__) 
+
+#define hit_on(...) pos.this_thread()->hit_on_impl(__FILE__ ":" stringify(__LINE__) " : hit_on(" stringifyany(__VA_ARGS__)  ")" ,__VA_ARGS__)
+#define mean_of(...) pos.this_thread()->mean_of_impl(__FILE__ ":" stringify(__LINE__) " : mean_of(" stringify(__VA_ARGS__)  ")" ,__VA_ARGS__)
 
 #endif // #ifndef MISC_H_INCLUDED

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1730,11 +1730,16 @@ void MainThread::check_time() {
 
   TimePoint elapsed = Time.elapsed();
   TimePoint tick = Limits.startTime + elapsed;
-
-  if (tick - lastInfoTime >= 1000)
+  TimePoint updatediff =  Limits.use_time_management()?TimePoint(3000)
+        : std::min(elapsed/16,TimePoint(3000));
+  if (tick - lastInfoTime >= updatediff)
   {
       lastInfoTime = tick;
       dbg_print();
+    for (Thread* th : Threads)
+    {
+      th->dbg_print2();
+    }
   }
 
   // We should not stop pondering until told so by the GUI

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -21,6 +21,10 @@
 #include <cassert>
 
 #include <algorithm> // For std::count
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
 #include "movegen.h"
 #include "search.h"
 #include "thread.h"
@@ -217,4 +221,48 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
   setupStates->back() = tmp;
 
   main()->start_searching();
+}
+
+
+void Thread::hit_on_impl(loc_file_line info_str, bool b)
+{
+
+    ++print_hits[info_str][0];
+    if (b)
+        ++print_hits[info_str][1];
+}
+
+void Thread::hit_on_impl(loc_file_line info_str, bool c, bool b)
+{
+    if (c)
+        Thread::hit_on_impl(info_str, b);
+}
+
+void Thread::mean_of_impl(loc_file_line info_str, int v)
+{
+
+    ++print_means[info_str][0];
+    print_means[info_str][1] += v;
+}
+
+
+void Thread::dbg_print2()
+{
+
+    for (auto& it : this->print_hits)
+    {
+
+        if (it.second[0])
+            std::cerr << std::endl
+                      << it.first << "\nThread:" << Thread::idx << "\n Total:   " << it.second[0]
+                      << "\nHits:    " << it.second[1]
+                      << "\nHitrate: " << (100.0 * it.second[1]) / it.second[0] << "%" << std::endl;
+    }
+    for (auto& it : this->print_means)
+    {
+        if (it.second[0])
+            std::cerr << std::endl
+                      << it.first << "\nThread:" << Thread::idx << "\nTotal: " << it.second[0]
+                      << "\nMean:  " << (double)it.second[1] / it.second[0] << std::endl;
+    }
 }

--- a/src/thread.h
+++ b/src/thread.h
@@ -26,6 +26,8 @@
 #include <mutex>
 #include <thread>
 #include <vector>
+#include <map>
+#include <string>
 
 #include "material.h"
 #include "movepick.h"
@@ -34,6 +36,9 @@
 #include "search.h"
 #include "thread_win32_osx.h"
 
+typedef const char*    loc_file_line; 
+typedef std::atomic<int64_t> int64StoreAtomic[2]; 
+typedef std::map < loc_file_line , int64StoreAtomic   > Atomic64Map;
 
 /// Thread class keeps together all the thread-related stuff. We use
 /// per-thread pawn and material hash tables so that once we get a
@@ -74,6 +79,12 @@ public:
   CapturePieceToHistory captureHistory;
   ContinuationHistory continuationHistory[2][2];
   Score contempt;
+  Atomic64Map print_hits;
+  Atomic64Map print_means;
+  void hit_on_impl(loc_file_line info_str,bool b);
+  void hit_on_impl(loc_file_line info_str,bool c, bool b);
+  void mean_of_impl(loc_file_line info_str,int v);
+  void dbg_print2();
 };
 
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -60,6 +60,7 @@ void init(OptionsMap& o) {
   constexpr int MaxHashMB = Is64Bit ? 131072 : 2048;
 
   o["Debug Log File"]        << Option("", on_logger);
+  o["Custom"]                << Option(0, INT32_MIN, INT32_MAX);
   o["Contempt"]              << Option(24, -100, 100);
   o["Analysis Contempt"]     << Option("Both var Off var White var Black var Both", "Both");
   o["Threads"]               << Option(1, 1, 512, on_threads);


### PR DESCRIPTION
* Move stringify to misc.h

Makes stringify available to other files.

* Add macros and UCI support

Add uci.h for uci variable testing
Add debug macros hit_on/mean_of.

* Thread-local dbg_print2

Add dbg_print2 which performs per thread.
Allows to zoom into early search with elapsed/16 interval.

* Add thread-local debug function implementations

Adds dbg_print2,hit_on_impl,mean_of_impl and support for printing.

* Add thread-local maps for printing

* Add custom variable support